### PR TITLE
feat: 윈도우 환경에서 프레임리스에서도 창에 관련된 액션을 취할 수 있게 titleBarOverlay 설정 추가

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -20,6 +20,7 @@ function createWindow(): void {
     minWidth: 1280,
     minHeight: 700,
     titleBarStyle: "hidden",
+    titleBarOverlay: (process.platform !== 'darwin' ? true : false),
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,


### PR DESCRIPTION
- 운영체제에 따라 titleBarOverlay 옵션이 true 또는 false로 지정되도록 변경